### PR TITLE
feat: Add basic structure for Tool C (Medical Co-pilot)

### DIFF
--- a/src/app/copilot/.gitkeep
+++ b/src/app/copilot/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure Git tracks the directory.

--- a/src/app/copilot/page.tsx
+++ b/src/app/copilot/page.tsx
@@ -1,0 +1,14 @@
+// src/app/copilot/page.tsx
+import React from 'react';
+import CopilotDisplay from '@/components/copilot/CopilotDisplay';
+
+const CopilotPage = () => {
+  return (
+    <div style={{ padding: '20px', textAlign: 'center' }}>
+      <h1>Tool C: Medical Co-pilot</h1>
+      <CopilotDisplay />
+    </div>
+  );
+};
+
+export default CopilotPage;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -59,6 +59,16 @@ export default function Navbar({ currentPath }: NavbarProps) {
             >
               Diagnostic Advisor
             </Link>
+            <Link
+              href="/copilot"
+              className={`${
+                isActive('/copilot')
+                  ? 'border-blue-500 text-gray-900'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+              } inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium`}
+            >
+              Co-pilot
+            </Link>
           </div>
         </div>
 

--- a/src/components/copilot/.gitkeep
+++ b/src/components/copilot/.gitkeep
@@ -1,0 +1,1 @@
+# This file is intentionally left blank to ensure Git tracks the directory.

--- a/src/components/copilot/CopilotDisplay.tsx
+++ b/src/components/copilot/CopilotDisplay.tsx
@@ -1,0 +1,14 @@
+// src/components/copilot/CopilotDisplay.tsx
+import React from 'react';
+
+const CopilotDisplay = () => {
+  return (
+    <div>
+      <h2>Medical Co-pilot Interface</h2>
+      <p>Real-time assistance and suggestions will appear here.</p>
+      {/* Placeholder for future UI elements */}
+    </div>
+  );
+};
+
+export default CopilotDisplay;

--- a/tests/frontend/unit/pages/copilot.test.tsx
+++ b/tests/frontend/unit/pages/copilot.test.tsx
@@ -1,0 +1,22 @@
+// tests/frontend/unit/pages/copilot.test.tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CopilotPage from '@/app/copilot/page';
+
+// Mock the CopilotDisplay component as it's not the focus of this page test
+vi.mock('@/components/copilot/CopilotDisplay', () => ({
+  default: () => <div data-testid="copilot-display-mock">Mocked Copilot Display</div>,
+}));
+
+describe('CopilotPage', () => {
+  it('renders the main heading', () => {
+    render(<CopilotPage />);
+    expect(screen.getByRole('heading', { name: /Tool C: Medical Co-pilot/i })).toBeInTheDocument();
+  });
+
+  it('renders the mocked CopilotDisplay component', () => {
+    render(<CopilotPage />);
+    expect(screen.getByTestId('copilot-display-mock')).toBeInTheDocument();
+    expect(screen.getByText('Mocked Copilot Display')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This commit introduces the initial file and directory structure for the aspirational Tool C (Medical Co-pilot).

Key changes:
- Created `src/app/copilot/page.tsx` for the main Tool C page.
- Created `src/components/copilot/CopilotDisplay.tsx` for Tool C's UI.
- Integrated `CopilotDisplay` into the `CopilotPage`.
- Added a navigation link to "Co-pilot" in the main Navbar.
- Added a basic unit test for the `CopilotPage` to ensure it renders.

This provides the foundational framework for future development of the Medical Co-pilot feature.